### PR TITLE
wallet: auto-reply over Tor when scanning an Invoice1 slatepack

### DIFF
--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -1070,23 +1070,41 @@ impl Wallet {
 		}
 	}
 
-	/// Send slate to Tor address.
-	async fn send_tor(&self, id: u32, s: &Slate, addr: &SlatepackAddress) -> Result<Slate, Error> {
+	/// Send slate to Tor address. When `finalize` is true, posts the slate to the
+	/// peer's foreign-api `finalize_tx` (used by the invoice-flow payer to push the
+	/// signed Invoice2 back to the merchant for broadcast); otherwise posts to
+	/// `receive_tx` (standard send flow).
+	async fn send_tor(
+		&self,
+		id: u32,
+		s: &Slate,
+		addr: &SlatepackAddress,
+		finalize: bool,
+	) -> Result<Slate, Error> {
 		self.on_tx_action(id, Some(WalletTxAction::SendingTor));
 
 		let tor_addr = OnionV3Address::try_from(addr).unwrap().to_http_str();
 		let url = format!("{}/v2/foreign", tor_addr);
 		let slate_send = VersionedSlate::into_version(s.clone(), SlateVersion::V4)?;
-		let body = json!({
-			"jsonrpc": "2.0",
-			"method": "receive_tx",
-			"id": 1,
-			"params": [
-						slate_send,
-						null,
-						null
-					]
-		})
+		let body = if finalize {
+			json!({
+				"jsonrpc": "2.0",
+				"method": "finalize_tx",
+				"id": 1,
+				"params": [slate_send]
+			})
+		} else {
+			json!({
+				"jsonrpc": "2.0",
+				"method": "receive_tx",
+				"id": 1,
+				"params": [
+							slate_send,
+							null,
+							null
+						]
+			})
+		}
 		.to_string();
 		// Wait Tor service to launch.
 		while Tor::is_service_starting(&self.identifier()) {
@@ -1136,7 +1154,7 @@ impl Wallet {
 	}
 
 	/// Handle message from the invoice issuer to send founds, return response for funds receiver.
-	fn pay(&self, slate: &Slate) -> Result<Slate, Error> {
+	fn pay(&self, slate: &Slate, dest: Option<SlatepackAddress>) -> Result<Slate, Error> {
 		let config = self.get_config();
 		let args = InitTxArgs {
 			src_acct_name: None,
@@ -1151,8 +1169,9 @@ impl Wallet {
 		let slate = api.process_invoice_tx(self.keychain_mask().as_ref(), &slate, args)?;
 		api.tx_lock_outputs(self.keychain_mask().as_ref(), &slate)?;
 
-		// Create Slatepack message response.
-		let _ = self.create_slatepack_message(&slate, None)?;
+		// Create Slatepack message response (kept as on-disk paste-back fallback even
+		// when an auto-Tor reply is attempted by the caller).
+		let _ = self.create_slatepack_message(&slate, dest)?;
 
 		Ok(slate)
 	}
@@ -1744,7 +1763,7 @@ fn start_sync(wallet: Wallet) -> Thread {
 /// Handle wallet task.
 async fn handle_task(w: &Wallet, t: WalletTask) {
 	let send_tor = async |tx: TxLogEntry, s: &Slate, r: &SlatepackAddress| match w
-		.send_tor(tx.id, &s, r)
+		.send_tor(tx.id, &s, r, false)
 		.await
 	{
 		Ok(s) => match w.finalize(&s, tx.id) {
@@ -1765,6 +1784,23 @@ async fn handle_task(w: &Wallet, t: WalletTask) {
 		},
 		Err(e) => {
 			error!("send tor error: {:?}", e);
+			w.on_tx_error(tx.id, Some(e));
+			w.on_task_result(Some(tx), &t);
+		}
+	};
+	// Invoice-flow counterpart to send_tor. After signing an Invoice2 the payer
+	// posts the slate to the merchant's foreign-api finalize_tx; the merchant
+	// finalizes + broadcasts on their side, so no local finalize/post is needed.
+	let pay_tor = async |tx: TxLogEntry, s: &Slate, r: &SlatepackAddress| match w
+		.send_tor(tx.id, &s, r, true)
+		.await
+	{
+		Ok(_) => {
+			sync_wallet_data(&w, false);
+			w.on_task_result(Some(tx), &t);
+		}
+		Err(e) => {
+			error!("pay tor error: {:?}", e);
 			w.on_tx_error(tx.id, Some(e));
 			w.on_task_result(Some(tx), &t);
 		}
@@ -1804,9 +1840,24 @@ async fn handle_task(w: &Wallet, t: WalletTask) {
 				match s.state {
 					SlateState::Standard1 | SlateState::Invoice1 => {
 						if s.state != SlateState::Standard1 {
-							if let Ok(_) = w.pay(&s) {
+							// Invoice1: sign + lock outputs. If the slatepack embedded a
+							// sender address and our Tor service is up, also push the
+							// signed Invoice2 back to the merchant for broadcast — the
+							// on-disk slatepack is still written as a paste-back fallback.
+							if let Ok(signed) = w.pay(&s, dest.clone()) {
 								sync_wallet_data(&w, false);
 								let tx = w.retrieve_tx_by_id(None, Some(s.id));
+								if let Some(addr) = dest {
+									let id = w.identifier();
+									if tx.is_some()
+										&& (Tor::is_service_running(&id)
+											|| Tor::is_service_starting(&id))
+									{
+										w.message_opening.store(false, Ordering::Relaxed);
+										pay_tor(tx.unwrap(), &signed, &addr).await;
+										return;
+									}
+								}
 								w.on_task_result(tx, &t);
 							}
 						} else {


### PR DESCRIPTION
## Summary

Mirrors the existing Standard1 + Send-task flow for the invoice
direction. When a customer scans an Invoice1 slatepack QR with an
embedded sender address, the patched `pay()` forwards the sender
address through `create_slatepack_message`, and the `OpenMessage`
handler — if the wallet's Tor service is running or starting —
pushes the signed Invoice2 to the merchant's foreign-api
`finalize_tx` over Tor. The merchant's wallet finalizes and posts
on their side, so no local finalize/post is needed (cf. the
existing `send_tor` closure for Standard1, which does need that).

Closes the mobile-UX gap where a customer scanning a Grin invoice
QR had to manually copy the response slatepack from the wallet
and paste it back to the merchant's web/storefront. With this
patch, scanning an invoice QR is now a single tap: **scan →
confirm → done**.

## What the patch touches

Single file, `src/wallet/wallet.rs`:

1. **`send_tor()`** gains a `finalize: bool` parameter that
   switches the JSON-RPC body between `receive_tx` (existing
   behavior for Standard1 send) and `finalize_tx` (new path for
   the invoice flow). Same Tor SOCKS plumbing handles both.

2. **`pay()`** gains a `dest: Option<SlatepackAddress>` parameter
   (mirroring `receive()`) and forwards it to
   `create_slatepack_message`. The on-disk response slatepack
   continues to be written, so paste-back is always available as
   a fallback.

3. **`handle_task`** gains a sibling `pay_tor` closure to
   `send_tor`, used in the `OpenMessage::Invoice1` arm when the
   parsed slatepack has a sender address and the wallet's Tor
   service is running. Unlike `send_tor`, `pay_tor` does **not**
   finalize/post locally — the merchant does that on their side.

4. **`OpenMessage::Invoice1` arm** passes `dest.clone()` to
   `pay()` and, when the wallet's Tor service is up + a sender
   address is present, awaits `pay_tor()` and returns. Otherwise
   falls through to the existing write-to-disk paste-back path
   unchanged.

## Backward compatibility

- Slatepacks without an embedded sender address (older issuers,
  or anything that explicitly omits the field) fall through to
  the existing on-disk paste-back path. No regression.
- Tor send failures (no circuit, peer offline, onion unreachable)
  are logged and surface via `on_tx_error` + `on_task_result`.
  The on-disk response slatepack was already written before the
  Tor send was attempted, so the customer can always recover by
  pasting it back manually.
- No protocol change, no new dependencies, no new state to
  persist.

## Privacy / security review

- The sender's slatepack address is already embedded in the
  slatepack by the issuer (it's how merchants identify which
  customer signed the response in any flow). Auto-using it for
  the reply doesn't reveal anything the merchant didn't already
  receive.
- Outbound Tor send to a slatepack-embedded onion is the same
  security surface as `grin-wallet send -m tor -d <addr>`. Same
  arti SOCKS5 proxy, same circuit semantics.
- No change to keystore, no change to identity.

## Real-world validation

End-to-end working today on a production BTCPay deployment using
the [Such-Software btcpayserver-grin-plugin v1.3.5][1] (released
2026-06-22). The merchant runs `grin-wallet listen` with a Tor
hidden service exposed; a patched Grim build on Android scans the
invoice QR, signs it, posts the Invoice2 over Tor, and the
merchant's BTCPay invoice settles after `min_confirmations` with
zero customer interaction beyond the initial scan.

The plugin-side counterpart picks up these payments by polling
the merchant wallet's `tx_log` for `kernel_excess` on the
invoice's recorded `slate_id` — an indicator that
`finalize_tx` already ran — and promotes the invoice through
its existing `Broadcast → Confirmed → Settled` state machine.
That work is independent of this PR and lives in the plugin,
but it's evidence the architecture works as designed.

[1]: https://github.com/Such-Software/btcpayserver-plugin-grin/releases/tag/v1.3.5

## Test plan

- [x] Builds for Android arm64-v8a (`scripts/android.sh build v8`,
      Cargo profile `release-apk`)
- [x] End-to-end Tor-finalize against a real merchant
      `grin-wallet listen` instance (mainnet)
- [x] Paste-back fallback still works when Tor service isn't up
      (no behavioral change for that path)
- [ ] Standard1 + Send-task Tor flow unchanged (please verify in
      review — the only call-site change for that path is the
      `false` literal added to the existing `send_tor` invocation)

Happy to iterate on the approach or the naming — this is the
minimum-diff version, but I'm open to factoring it differently if
maintainers prefer.